### PR TITLE
add callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ easy_tags_on :bees
 ## Testing
 ```
 bundle exec appraisal install
-bundle exec appraisal spec
+bundle exec appraisal rspec
 ```
 
 ## Development

--- a/lib/easy_tags.rb
+++ b/lib/easy_tags.rb
@@ -22,6 +22,7 @@ module EasyTags
   end
 
   module Options
+    autoload :Callback, 'easy_tags/options/callback'
     autoload :Item, 'easy_tags/options/item'
     autoload :Collection, 'easy_tags/options/collection'
   end

--- a/lib/easy_tags/options/callback.rb
+++ b/lib/easy_tags/options/callback.rb
@@ -1,0 +1,32 @@
+module EasyTags
+  module Options
+    # Represents a single callback item
+    class Callback
+      attr_reader :context
+
+      TYPES = %i[after_add after_remove]
+
+      def initialize(callback:, type:)
+        @callback = callback
+        @type = type
+
+        unless TYPES.include?(type)
+          raise "unknown callback type - must be one of #{TYPES}"
+        end
+      end
+
+      # @return [String]
+      def type
+        @type
+      end
+
+      def run(taggable:, tagging:)
+        if @callback.is_a?(Symbol)
+          taggable.send(@callback, tagging)
+        elsif @callback.is_a?(Proc)
+          taggable.instance_exec tagging, &@callback
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_tags/options/collection.rb
+++ b/lib/easy_tags/options/collection.rb
@@ -12,8 +12,8 @@ module EasyTags
       end
 
       # @return [String]
-      def filter
-        filtered_options.map(&:filter)
+      def items
+        filtered_options
       end
 
       private

--- a/lib/easy_tags/options/item.rb
+++ b/lib/easy_tags/options/item.rb
@@ -8,13 +8,32 @@ module EasyTags
 
       # @return [Boolean]
       def valid?
-        /[@$"]/ !~ filter.inspect
+        /[@$"]/ !~ name.inspect
       end
 
       # @return [Symbol]
-      def filter
-        @_filter ||= @option.to_sym
+      def name
+        @_filter ||= key.to_sym
       end
+
+      def callbacks
+        return [] unless has_callbacks?
+
+        @option.values.map do |callback|
+          Callback.new(callback: callback.values.first, type: callback.keys.first)
+        end
+      end
+
+      private
+
+        def key
+          return @option.keys.first if has_callbacks?
+          @option
+        end
+
+        def has_callbacks?
+          @option.is_a?(Hash)
+        end
     end
   end
 end

--- a/lib/easy_tags/tag.rb
+++ b/lib/easy_tags/tag.rb
@@ -9,8 +9,27 @@ module EasyTags
     validates_uniqueness_of :name
     validates_length_of :name, maximum: 255
 
+    after_commit :notify_add, on: :create
+    after_commit :notify_remove, on: :destroy
+
     def to_s
       name
     end
+
+    private
+
+      def notify_add
+        ActiveSupport::Notifications.instrument(
+          'easy_tag.tag_added',
+          tag: self
+        )
+      end
+
+      def notify_remove
+        ActiveSupport::Notifications.instrument(
+          'easy_tag.tag_removed',
+          tag: self
+        )
+      end
   end
 end

--- a/lib/easy_tags/tag.rb
+++ b/lib/easy_tags/tag.rb
@@ -3,7 +3,7 @@ module EasyTags
   class Tag < ::ActiveRecord::Base
     self.table_name = EasyTags.tags_table
 
-    has_many :taggings, dependent: :destroy, class_name: '::EasyTags::Tagging'
+    has_many :taggings, dependent: :destroy, class_name: '::EasyTags::Tagging', inverse_of: :tag
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/lib/easy_tags/tag_list.rb
+++ b/lib/easy_tags/tag_list.rb
@@ -27,6 +27,10 @@ module EasyTags
       generator.generate(self)
     end
 
+    def remove(value)
+      __getobj__.delete(value)
+    end
+
     private
 
       attr_accessor :generator, :parser

--- a/lib/easy_tags/taggable.rb
+++ b/lib/easy_tags/taggable.rb
@@ -5,17 +5,23 @@ module EasyTags
         []
       end
 
+      cattr_accessor :tagging_callbacks do
+        {}
+      end
+
       def easy_tags_on(*tagging_contexts_params)
         options = Options::Collection.new(tagging_contexts_params.to_a)
         raise 'invalid options' unless options.valid?
 
-        tagging_contexts.push(*options.filter)
-        tagging_contexts.uniq!
+        options.items.each do |option|
+          next if tagging_contexts.include?(option.name)
 
-        tagging_contexts.each do |context|
+          tagging_contexts.push(option.name)
+          tagging_callbacks[option.name] = option.callbacks
+
           EasyTags::TaggableContextMethods.inject(
             class_instance: self,
-            context: context
+            context: option.name
           )
         end
       end

--- a/lib/easy_tags/taggable_methods.rb
+++ b/lib/easy_tags/taggable_methods.rb
@@ -4,8 +4,21 @@ module EasyTags
     class << self
       def inject(class_instance:)
         class_instance.class_eval do
-          has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::EasyTags::Tagging'
-          has_many :base_tags, through: :taggings, source: :tag, class_name: '::EasyTags::Tag'
+          has_many(
+            :taggings,
+            as: :taggable,
+            dependent: :destroy,
+            class_name: '::EasyTags::Tagging',
+            inverse_of: :taggable
+          )
+
+          has_many(
+            :base_tags,
+            through: :taggings,
+            source: :tag,
+            class_name: '::EasyTags::Tag',
+            inverse_of: :tag
+          )
 
           after_save :_update_taggings, :_refresh_tagging
           after_find :_refresh_tagging
@@ -66,20 +79,20 @@ module EasyTags
               )
             end
 
-            def _notify_tag_add(tagging)
+            def _notify_tag_change(type:, tagging:)
               self.class.tagging_callbacks[tagging.context.to_sym].select do |callback|
-                callback.type == :after_add
+                callback.type == type
               end.each do |callback|
                 callback.run(taggable: self, tagging: tagging)
               end
             end
 
+            def _notify_tag_add(tagging)
+              _notify_tag_change(type: :after_add, tagging: tagging)
+            end
+
             def _notify_tag_remove(tagging)
-              self.class.tagging_callbacks[tagging.context.to_sym].select do |callback|
-                callback.type == :after_remove
-              end.each do |callback|
-                callback.run(taggable: self, tagging: tagging)
-              end
+              _notify_tag_change(type: :after_remove, tagging: tagging)
             end
           end
       end

--- a/lib/easy_tags/tagging.rb
+++ b/lib/easy_tags/tagging.rb
@@ -3,8 +3,8 @@ module EasyTags
   class Tagging < ::ActiveRecord::Base
     self.table_name = EasyTags.taggings_table
 
-    belongs_to :tag, class_name: '::EasyTags::Tag', optional: false
-    belongs_to :taggable, polymorphic: true, optional: false
+    belongs_to :tag, class_name: '::EasyTags::Tag', optional: false, inverse_of: :taggings
+    belongs_to :taggable, polymorphic: true, optional: false, inverse_of: :taggings
 
     validates_uniqueness_of :tag_id, scope: %i[taggable_type taggable_id context]
 

--- a/lib/easy_tags/tagging.rb
+++ b/lib/easy_tags/tagging.rb
@@ -3,16 +3,32 @@ module EasyTags
   class Tagging < ::ActiveRecord::Base
     self.table_name = EasyTags.taggings_table
 
-    DEFAULT_CONTEXT = 'tags'.freeze
-
-    belongs_to :tag, class_name: '::EasyTags::Tag'
-    belongs_to :taggable, polymorphic: true
-
-    scope :by_context, ->(context = DEFAULT_CONTEXT) { where(context: context) }
-
-    validates_presence_of :context
-    validates_presence_of :tag_id
+    belongs_to :tag, class_name: '::EasyTags::Tag', optional: false
+    belongs_to :taggable, polymorphic: true, optional: false
 
     validates_uniqueness_of :tag_id, scope: %i[taggable_type taggable_id context]
+
+    after_commit :notify_add, on: :create
+    after_commit :notify_remove, on: :destroy
+
+    private
+
+      def notify_add
+        ActiveSupport::Notifications.instrument(
+          "easy_tag.tagging_added.#{taggable_type.to_s.tableize}.#{context}",
+          tagging: self
+        )
+
+        taggable.send(:_notify_tag_add, self)
+      end
+
+      def notify_remove
+        ActiveSupport::Notifications.instrument(
+          "easy_tag.tagging_added#{taggable_type.to_s.tableize}.#{context}",
+          tagging: self
+        )
+
+        taggable.send(:_notify_tag_remove, self)
+      end
   end
 end


### PR DESCRIPTION
Closes #2  
Closes #8 

add callback support
```ruby
easy_tags_on(
  :bees, 
  birds: { after_add: :add_callback },
  butterflies: { after_remove: -> (tagging) { remove_callback(tagging) } }
)
```