### PR TITLE
fix dirty behavior for add and remove

### DIFF
--- a/lib/easy_tags/taggable_context.rb
+++ b/lib/easy_tags/taggable_context.rb
@@ -30,7 +30,7 @@ module EasyTags
     def update(value)
       @tags = TagList.new(value)
 
-      on_change.call(self) if changed?
+      notify_change
     end
 
     # @return [TagList]
@@ -49,8 +49,46 @@ module EasyTags
       @persisted_tags = nil
     end
 
+    # Add tags to the tag_list. Duplicate or blank tags will be ignored.
+    #
+    # Example:
+    #   tag_list.add('Fun', 'Happy')
+    def add(*names)
+      tags.add(*names).tap do
+        notify_change
+      end
+    end
+
+    # Remove item from list
+    #
+    # Example:
+    #   tag_list.remove('Issues')
+    def remove(value)
+      tags.remove(value).tap do
+        notify_change
+      end
+    end
+
+    def ==(other)
+      to_a == other.to_a
+    end
+
     private
 
       attr_accessor :context, :refresh_persisted_tags, :on_change
+
+      def respond_to_missing?(name, _include_private = false)
+        tags.respond_to?(name)
+      end
+
+      def method_missing(name, *args, &block)
+        return super unless respond_to_missing?(name)
+
+        tags.send(name, *args, &block)
+      end
+
+      def notify_change
+        on_change.call(self) if changed?
+      end
   end
 end

--- a/lib/easy_tags/taggable_context_methods.rb
+++ b/lib/easy_tags/taggable_context_methods.rb
@@ -33,7 +33,7 @@ module EasyTags
           attribute :#{context}_list, ActiveModel::Type::Value.new
 
           def #{context}
-            _taggable_context(:#{context}).tags
+            _taggable_context(:#{context})
           end
 
           def #{context}=(value)

--- a/spec/easy_tags/dirty_spec.rb
+++ b/spec/easy_tags/dirty_spec.rb
@@ -112,6 +112,48 @@ RSpec.describe 'Dirty behavior of taggable objects' do
 
         it_behaves_like 'implements dirty when attributes do not change'
       end
+
+      context '#add' do
+        before do
+          expect(taggable.changes).to be_empty
+          taggable.tags.add('one')
+        end
+
+        it_behaves_like 'implements dirty when attribute changes' do
+          let(:changes_hash) { { 'tags_list' => ['awesome,epic', 'awesome,epic,one'] } }
+          let(:changes_array) { ['awesome,epic', 'awesome,epic,one'] }
+          let(:previous_value) { 'awesome,epic' }
+        end
+      end
+
+      context '#remove' do
+        before do
+          expect(taggable.changes).to be_empty
+          taggable.tags.remove('awesome')
+        end
+
+        it_behaves_like 'implements dirty when attribute changes' do
+          let(:changes_hash) { { 'tags_list' => ['awesome,epic', 'epic'] } }
+          let(:changes_array) { ['awesome,epic', 'epic'] }
+          let(:previous_value) { 'awesome,epic' }
+        end
+      end
+
+      context 'multiple #add/#remove changes' do
+        before do
+          expect(taggable.changes).to be_empty
+          taggable.tags.add('one')
+          taggable.tags.add('two')
+          taggable.tags.add('three')
+          taggable.tags.remove('two')
+        end
+
+        it_behaves_like 'implements dirty when attribute changes' do
+          let(:changes_hash) { { 'tags_list' => ['awesome,epic', 'awesome,epic,one,three'] } }
+          let(:changes_array) { ['awesome,epic', 'awesome,epic,one,three'] }
+          let(:previous_value) { 'awesome,epic' }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
fixes dirty behavior for context `.add` and `.remove` methods