### PR TITLE
remove activerecord-5.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,3 @@
-appraise 'activerecord-5.0' do
-  gem 'activerecord', '~> 5.0.0'
-  gem 'activesupport', '~> 5.0.0'
-end
-
 appraise 'activerecord-5.1' do
   gem 'activerecord', '~> 5.1.0'
   gem 'activesupport', '~> 5.1.0'


### PR DESCRIPTION
remove activerecord-5.0 from Appraisals configuration, support was removed in `0.2.3` with https://github.com/iiwo/easy_tags/pull/26