### PR TITLE
remove base_tags association

### DIFF
--- a/lib/easy_tags/taggable_methods.rb
+++ b/lib/easy_tags/taggable_methods.rb
@@ -14,14 +14,6 @@ module EasyTags
             inverse_of: :taggable
           )
 
-          has_many(
-            :base_tags,
-            through: :taggings,
-            source: :tag,
-            class_name: '::EasyTags::Tag',
-            inverse_of: :tag
-          )
-
           after_save :_update_taggings, :_refresh_tagging
           after_find :_refresh_tagging
 


### PR DESCRIPTION
dead code, not used anywhere - this is actually broken and is rising  `ActiveRecord::InverseOfAssociationNotFoundError: Could not find the inverse association for base_tags`