### PR TITLE
handle eager loading properly

### DIFF
--- a/easy_tags.gemspec
+++ b/easy_tags.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'database_cleaner'
+  spec.add_development_dependency 'db-query-matchers'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'simplecov'

--- a/lib/easy_tags/taggable_methods.rb
+++ b/lib/easy_tags/taggable_methods.rb
@@ -62,9 +62,7 @@ module EasyTags
             def _taggable_context(context)
               _taggable_contexts[context] ||= TaggableContext.new(
                 context: context,
-                refresh_persisted_tags: lambda {
-                  taggings.joins(:tag).where(context: context).pluck(:name)
-                },
+                tags_association: public_send("#{context}_tags"),
                 on_change: lambda { |tag_context|
                   _mark_dirty(context: context, taggable_context: tag_context)
                 }

--- a/spec/easy_tags/context_methods_spec.rb
+++ b/spec/easy_tags/context_methods_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe 'context methods' do
     end
   end
 
+  describe '#context_tags' do
+    describe 'eager loading' do
+      subject do
+        TaggableModel.includes(:bees_tags).map do |tagabble|
+          tagabble.bees.to_s
+        end
+      end
+
+      before do
+        10.times do
+          taggable = TaggableModel.create
+          create_tag_for(taggable: taggable, tag_name: 'bumble')
+        end
+      end
+
+      it 'preloads tags' do
+        expect { subject }.to make_database_queries(count: 2..3) # 5.1 only makes 2 queries
+      end
+    end
+  end
+
   describe '#context_list_persisted' do
     before do
       taggable.bees_list = 'bumble, busy'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'easy_tags'
 require 'database_cleaner'
 require 'simplecov'
 require 'simplecov-console'
+require 'db-query-matchers'
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 


### PR DESCRIPTION
fixes eager loading by removing the `pluck` usage and using the context defined, preloaded association for populating tag name values