### PR TITLE
fix bug with reload method arguments forwarding

### DIFF
--- a/lib/easy_tags/taggable_methods.rb
+++ b/lib/easy_tags/taggable_methods.rb
@@ -19,7 +19,7 @@ module EasyTags
 
           # override ActiveRecord::Persistence#reload
           # to refresh tags each time the model instance gets reloaded
-          def reload
+          def reload(*args)
             _refresh_tagging
             super
           end


### PR DESCRIPTION
Forward `reload` arguments. Fixes https://github.com/iiwo/easy_tags/issues/36