### PR TITLE
Allow for Rails 8 and beyond

### DIFF
--- a/easy_tags.gemspec
+++ b/easy_tags.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['>= 2.5.0', '<= 4.0.0']
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 8'
-  spec.add_runtime_dependency 'activesupport', '>= 5.0', '< 8'
+  spec.add_runtime_dependency 'activerecord', '>= 5.0'
+  spec.add_runtime_dependency 'activesupport', '>= 5.0'
 end


### PR DESCRIPTION
This removes the upward restriction for Rails (ActiveRecord/ActiveSupport) for easier upgrades. In my estimation, there should only be a blocker to a Rails version if it is not supported. This is the only Gem that behaves like this (preventing upgrades). This feels like a saner position. Let me know what you think.